### PR TITLE
2.2.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,8 +11,8 @@ const messagesDb = require('./lib/messages-db.js')
 if (versions.broken.includes(currentVersion)) {
     console.error(
         ol(`This version of macOS \(${currentVersion}) is known to be
-         incompatible with osa-imessage. Please upgrade either
-         macOS or osa-imessage.`)
+            incompatible with osa-imessage. Please upgrade either
+            macOS or osa-imessage.`)
     )
     process.exit(1)
 }
@@ -20,8 +20,8 @@ if (versions.broken.includes(currentVersion)) {
 if (!versions.working.includes(currentVersion)) {
     console.warn(
         ol(`This version of macOS \(${currentVersion}) is currently
-         untested with this version of osa-imessage. Proceed with
-         caution.`)
+            untested with this version of osa-imessage. Proceed with
+            caution.`)
     )
 }
 
@@ -140,9 +140,9 @@ function listen() {
             bail = true
             emitter.emit('error', err)
             console.error(
-                ol(`sqlite returned an error while polling for new message!
-            bailing out of poll routine for safety. new messages will
-            not be detected`)
+                ol(`sqlite returned an error while polling for new messages!
+                    bailing out of poll routine for safety. new messages will
+                    not be detected`)
             )
         }
     }

--- a/lib/messages-db.js
+++ b/lib/messages-db.js
@@ -1,0 +1,21 @@
+const sqlite = require('sqlite')
+const dbPath = `${process.env.HOME}/Library/Messages/chat.db`
+const OPEN_READONLY = 1
+
+let db
+async function open() {
+    if (db) return db
+    db = await sqlite.open(dbPath, { mode: OPEN_READONLY })
+    return db
+}
+
+function cleanUp() {
+    if (db) db.close()
+}
+process.on('exit', cleanUp)
+process.on('SIGINT', cleanUp)
+process.on('uncaughtException', cleanUp)
+
+module.exports = {
+    open,
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "osa-imessage",
-    "version": "2.1.2",
+    "version": "2.2.0",
     "description": "Bring the power of NodeJS to Apple iMessage",
     "author": {
         "name": "Will Franzen",
@@ -28,15 +28,13 @@
         "receive"
     ],
     "engines": {
-        "node": ">=6.4"
+        "node": ">=8"
     },
     "dependencies": {
         "macos-version": "^4.0.0",
         "one-liner": "^1.0.3",
-        "osa2": "^0.0.0"
-    },
-    "optionalDependencies": {
-        "sqlite3": "^3.1.8"
+        "osa2": "^0.0.0",
+        "sqlite": "^2.8.0"
     },
     "devDependencies": {
         "prettier": "^1.3.0"

--- a/readme.md
+++ b/readme.md
@@ -20,17 +20,19 @@ npm install osa-imessage --save
 Usage
 ====
 
-**Send a message**
+Be sure to require `osa-imessage`:
+
 ```js
 const imessage = require('osa-imessage')
+```
 
+**Send a message**
+```js
 imessage.send('+15555555555', 'Hello World!')
 ```
 
 **Receive messages**
 ```js
-const imessage = require('osa-imessage')
-
 imessage.listen().on('message', (msg) => {
     console.log(`'${msg.text}' from ${msg.handle}`)
 })
@@ -38,8 +40,6 @@ imessage.listen().on('message', (msg) => {
 
 **Send message to name**
 ```js
-const imessage = require('osa-imessage')
-
 imessage.handleForName('Tim Cook').then(handle => {
     imessage.send(handle, 'Hello')
 })
@@ -47,9 +47,12 @@ imessage.handleForName('Tim Cook').then(handle => {
 
 **Send message to group**
 ```js
-const imessage = require('osa-imessage')
-
 imessage.send('chat000000000000000000', 'Hello everyone!')
+```
+
+**Get recent chats**
+```js
+imessage.getRecentChats(20) // Defaults to 10
 ```
 
 API
@@ -140,3 +143,19 @@ The full name of the desired contact, as displayed in `Messages.app`.
 Type: `Promise<string>`
 
 A promise that resolves with the `handle` of the contact, or rejects if nobody was found.
+
+### Get recents chats
+
+`getRecentChats(limit) -> Promise`
+
+**limit**
+
+Type: `integer`
+
+Amount of recent chats to return.
+
+**return**
+
+Type: `Promise`
+
+A promise that resolves with an array of chats.


### PR DESCRIPTION
A couple things to note here:

- `requireSqlite()` was unnecessary imo. To hand wave over this fact, I included `sqlite` as an actual dep and not an optional one.
- I moved some of the db-specific logic into a module. This may seem unnecessary now, but I am setting myself up to make the code more organized and ultimately more testable once it comes time to write some units.
- `getRecentChats` returns a promise which resolves to an array of chats. The default limit is 10.