### PR TITLE
use debug instead of console.warn (https://www.npmjs.com/package/debug)

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ const fs = require('fs')
 const osa = require('osa2')
 const ol = require('one-liner')
 const assert = require('assert')
+const debug = require('debug')('osa-imessage')
 
 const versions = require('./macos_versions')
 const currentVersion = require('macos-version')()
@@ -9,7 +10,7 @@ const currentVersion = require('macos-version')()
 const messagesDb = require('./lib/messages-db.js')
 
 if (versions.broken.includes(currentVersion)) {
-    console.error(
+    debug(
         ol(`This version of macOS \(${currentVersion}) is known to be
             incompatible with osa-imessage. Please upgrade either
             macOS or osa-imessage.`)
@@ -18,7 +19,7 @@ if (versions.broken.includes(currentVersion)) {
 }
 
 if (!versions.working.includes(currentVersion)) {
-    console.warn(
+    debug(
         ol(`This version of macOS \(${currentVersion}) is currently
             untested with this version of osa-imessage. Proceed with
             caution.`)
@@ -139,7 +140,7 @@ function listen() {
         } catch (error) {
             bail = true
             emitter.emit('error', err)
-            console.error(
+            debug.error(
                 ol(`sqlite returned an error while polling for new messages!
                     bailing out of poll routine for safety. new messages will
                     not be detected`)

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
         "node": ">=8"
     },
     "dependencies": {
+        "debug": "^3.0.1",
         "macos-version": "^4.0.0",
         "one-liner": "^1.0.3",
         "osa2": "^0.0.0",

--- a/readme.md
+++ b/readme.md
@@ -159,3 +159,12 @@ Amount of recent chats to return.
 Type: `Promise`
 
 A promise that resolves with an array of chats.
+
+### Debugging osa-imessage
+
+We use the popular [debug](https://www.npmjs.com/package/debug) library.
+
+```
+$ DEBUG=* node ./myscript.js
+$ DEBUG=osa-imessage ./myscript.js
+```


### PR DESCRIPTION
So I use osa-imessage for [alfred-messages](https://github.com/briangonzalez/alfred-messages). These `console.warn`'s break Alfred functionality because Alfred tries to parse `stdout` and osa-imessage is littering it.

[debug](https://www.npmjs.com/package/debug) is super popular and great for this sort of use case.

Thoughts?